### PR TITLE
Check device field in cloud-config

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -55,7 +55,8 @@ func Run(automatic bool, configFile string, powerOff bool, reboot bool, noReboot
 	}
 
 	if automatic && !cfg.RancherOS.Install.Automatic {
-		return nil
+		fmt.Println("Running automatic installation, option -y will be enforced")
+		cfg.RancherOS.Install.Automatic = true
 	}
 
 	err = Ask(&cfg)


### PR DESCRIPTION
For automatted installation check device field
in cloud-config, when it is empty log this properly
and return error message to the user.

For -automatic option also -y will be enforced.

Fixes #https://github.com/rancher-sandbox/os2/issues/111

Signed-off-by: Michal Jura <mjura@suse.com>